### PR TITLE
Set ruby >= 2.4.1 as min required version

### DIFF
--- a/actionmailbox.gemspec
+++ b/actionmailbox.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/rails/actionmailbox"
   s.license  = "MIT"
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.4.1"
 
   s.add_dependency "rails", ">= 5.2.0"
 


### PR DESCRIPTION
This matches Rails master, and it should make TravisCI green/happy.