### PR TITLE
Fix ApplicationMailbox Generator

### DIFF
--- a/lib/generators/rails/mailbox_generator.rb
+++ b/lib/generators/rails/mailbox_generator.rb
@@ -10,11 +10,11 @@ module Rails
       check_class_collision suffix: "Mailbox"
 
       def create_mailbox_file
-        template "mailbox.rb", File.join("app/mailboxes", class_path, "#{file_name}_mailbox.rb")
-
         in_root do
-          if behavior == :invoke && !File.exist?(application_mailbox_file_name)
+          if behavior == :invoke && file_name == 'application'
             template "application_mailbox.rb", application_mailbox_file_name
+          else
+            template "mailbox.rb", File.join("app/mailboxes", class_path, "#{file_name}_mailbox.rb")
           end
         end
       end

--- a/test/generators/mailbox_generator_test.rb
+++ b/test/generators/mailbox_generator_test.rb
@@ -17,7 +17,11 @@ class MailboxGeneratorTest < Rails::Generators::TestCase
       assert_match(/def process/, mailbox)
       assert_no_match(%r{# routing /something/i => :somewhere}, mailbox)
     end
+  end
 
+  def test_application_mailbox_is_created
+    Object.send :remove_const, :ApplicationMailbox
+    run_generator ['application']
     assert_file "app/mailboxes/application_mailbox.rb" do |mailbox|
       assert_match(/class ApplicationMailbox < ActionMailbox::Base/, mailbox)
       assert_match(%r{# routing /something/i => :somewhere}, mailbox)


### PR DESCRIPTION
### Expected behavior
```
$ bin/rails action_mailbox:install
$ cat app/mailboxes/application_mailbox.rb
# frozen_string_literal: true

class ApplicationMailbox < ActionMailbox::Base
  # routing /something/i => :somewhere
end
```
### Actual behavior
```
$ bin/rails action_mailbox:install
$ cat app/mailboxes/application_mailbox.rb
# frozen_string_literal: true

classApplicationMailbox < ApplicationMailbox
  def process
  end
end
```